### PR TITLE
use v6.c, bump version number.

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "URI::Encode",
-    "version" : "0.07",
+    "version" : "0.08",
     "description" : "Encode and decode URIs according to RFC 3986",
     "authors" : [ "David Farrell" ],
     "build-depends" : [ ],

--- a/lib/URI/Encode.pm6
+++ b/lib/URI/Encode.pm6
@@ -1,3 +1,5 @@
+use v6.c;
+
 module URI::Encode:ver<0.05>
 {
     my $RFC3986_unreserved = rx/<[0..9A..Za..z\-.~_]>/;


### PR DESCRIPTION
Regex matches fail in v6.d due to lexical topic changes.

See rakudo/rakudo#2608 for further context.