### PR TITLE
Use correct SPDX identifier in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "depends": [
   ],
   "description": "a Raku module for encoding / decoding URIs",
-  "license": "FreeBSD",
+  "license": "BSD-2-Clause-FreeBSD",
   "name": "URI::Encode",
   "perl": "6.*",
   "provides": {


### PR DESCRIPTION
There is no "FreeBSD" SPDX identifier, based on a reading of the LICENSE file I believe you want https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html however you might want to consider moving to a non-deprecated license.